### PR TITLE
Http url templates plus urlencoded templates

### DIFF
--- a/lib/apphook.c
+++ b/lib/apphook.c
@@ -33,7 +33,7 @@
 #include "logsource.h"
 #include "logwriter.h"
 #include "afinter.h"
-#include "template/templates.h"
+#include "template/globals.h"
 #include "hostname.h"
 #include "mainloop-call.h"
 #include "service-management.h"

--- a/lib/cfg-grammar-internal.h
+++ b/lib/cfg-grammar-internal.h
@@ -77,7 +77,6 @@ extern LogSchedulerOptions *last_scheduler_options;
 extern LogParser *last_parser;
 extern FilterExprNode *last_filter_expr;
 extern LogTemplateOptions *last_template_options;
-extern LogTemplate *last_template;
 extern ValuePairs *last_value_pairs;
 extern ValuePairsTransformSet *last_vp_transset;
 extern LogMatcherOptions *last_matcher_options;

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -919,7 +919,9 @@ template_content_inner
         ;
 
 template_content
-        : <ptr>{ $$ = log_template_new(configuration, NULL); } template_content_inner	{ $$ = $1; }
+        : <ptr>{
+            $$ = log_template_new(configuration, NULL);
+          } template_content_inner					    { $$ = $1; }
         ;
 
 template_content_list

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -1432,7 +1432,6 @@ dest_writer_option
 	| KW_FLUSH_TIMEOUT '(' positive_integer ')'	{ }
         | KW_SUPPRESS '(' nonnegative_integer ')'            { last_writer_options->suppress = $3; }
 	| KW_TEMPLATE '(' template_name_or_content ')'       { last_writer_options->template = $3; }
-	| KW_TEMPLATE_ESCAPE '(' yesno ')'	{ log_writer_options_set_template_escape(last_writer_options, $3); }
 	| KW_PAD_SIZE '(' nonnegative_integer ')'         { last_writer_options->padding = $3; }
 	| KW_TRUNCATE_SIZE '(' nonnegative_integer ')'         { last_writer_options->truncate_size = $3; }
 	| KW_MARK_FREQ '(' nonnegative_integer ')'        { last_writer_options->mark_freq = $3; }
@@ -1473,6 +1472,7 @@ template_option
 	| KW_TIME_ZONE '(' string ')'		{ last_template_options->time_zone[LTZ_SEND] = g_strdup($3); free($3); }
 	| KW_SEND_TIME_ZONE '(' string ')'      { last_template_options->time_zone[LTZ_SEND] = g_strdup($3); free($3); }
 	| KW_LOCAL_TIME_ZONE '(' string ')'     { last_template_options->time_zone[LTZ_LOCAL] = g_strdup($3); free($3); }
+	| KW_TEMPLATE_ESCAPE '(' yesno ')'	{ last_template_options->escape = $3; }
 	| KW_ON_ERROR '(' string ')'
         {
           gint on_error;

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -874,6 +874,11 @@ template_items
 	|
 	;
 
+template_item
+	: KW_TEMPLATE '(' template_content_inner ')'
+	| KW_TEMPLATE_ESCAPE '(' yesno ')'	{ log_template_set_escape(last_template, $3); }
+	;
+
 /* START_RULES */
 
 template_content_inner
@@ -931,10 +936,6 @@ template_name_or_content
 
 /* END_RULES */
 
-template_item
-	: KW_TEMPLATE '(' template_content_inner ')'
-	| KW_TEMPLATE_ESCAPE '(' yesno ')'	{ log_template_set_escape(last_template, $3); }
-	;
 
 
 block_stmt

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -1115,6 +1115,22 @@ cfg_lexer_lex(CfgLexer *self, CFG_STYPE *yylval, CFG_LTYPE *yylloc)
 
           tok = cfg_lexer_lex_next_token(self, yylval, yylloc);
           cfg_lexer_append_preprocessed_output(self, self->token_pretext->str);
+
+          if (cfg_lexer_get_context_type(self) == LL_CONTEXT_TEMPLATE_REF)
+            {
+              cfg_lexer_pop_context(self);
+
+              if ((tok == LL_IDENTIFIER || tok == LL_STRING))
+                {
+
+                  LogTemplate *template = cfg_tree_lookup_template(&configuration->tree, yylval->cptr);
+                  if (template != NULL)
+                    {
+                      tok = LL_TEMPLATE_REF;
+                      log_template_unref(template);
+                    }
+                }
+            }
         }
 
       preprocess_result = cfg_lexer_preprocess(self, tok, yylval, yylloc);
@@ -1232,6 +1248,7 @@ static const gchar *lexer_contexts[] =
   [LL_CONTEXT_SERVER_PROTO] = "server-proto",
   [LL_CONTEXT_OPTIONS] = "options",
   [LL_CONTEXT_CONFIG] = "config",
+  [LL_CONTEXT_TEMPLATE_REF] = "template-ref",
 };
 
 gint

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -1938,19 +1938,6 @@ log_writer_options_defaults(LogWriterOptions *options)
 }
 
 void
-log_writer_options_set_template_escape(LogWriterOptions *options, gboolean enable)
-{
-  if (options->template && options->template->def_inline)
-    {
-      log_template_set_escape(options->template, enable);
-    }
-  else
-    {
-      msg_error("Macro escaping can only be specified for inline templates");
-    }
-}
-
-void
 log_writer_options_set_mark_mode(LogWriterOptions *options, const gchar *mark_mode)
 {
   options->mark_mode = cfg_lookup_mark_mode(mark_mode);

--- a/lib/template/CMakeLists.txt
+++ b/lib/template/CMakeLists.txt
@@ -2,6 +2,7 @@ set(TEMPLATE_HEADERS
     template/templates.h
     template/macros.h
     template/function.h
+    template/globals.h
     template/eval.h
     template/simple-function.h
     template/repr.h
@@ -15,6 +16,7 @@ set(TEMPLATE_SOURCES
     template/templates.c
     template/macros.c
     template/eval.c
+    template/globals.c
     template/simple-function.c
     template/repr.c
     template/compiler.c

--- a/lib/template/Makefile.am
+++ b/lib/template/Makefile.am
@@ -7,6 +7,7 @@ templateinclude_HEADERS = \
 	lib/template/templates.h		\
 	lib/template/macros.h			\
 	lib/template/function.h			\
+	lib/template/globals.h			\
 	lib/template/eval.h			\
 	lib/template/simple-function.h		\
 	lib/template/repr.h			\
@@ -18,6 +19,7 @@ templateinclude_HEADERS = \
 template_sources = \
 	lib/template/templates.c		\
 	lib/template/macros.c			\
+	lib/template/globals.c			\
 	lib/template/eval.c			\
 	lib/template/simple-function.c		\
 	lib/template/repr.c			\

--- a/lib/template/common-template-typedefs.h
+++ b/lib/template/common-template-typedefs.h
@@ -46,6 +46,7 @@ struct _LogTemplateOptions
   /* number of digits in the fraction of a second part, specified using frac_digits() */
   gint frac_digits;
   gboolean use_fqdn;
+  gboolean escape;
 
   /* timezone for LTZ_LOCAL/LTZ_SEND settings */
   gchar *time_zone[LTZ_MAX];

--- a/lib/template/common-template-typedefs.h
+++ b/lib/template/common-template-typedefs.h
@@ -25,7 +25,34 @@
 #ifndef COMMON_TYPEDEFS_H_INCLUDED
 #define COMMON_TYPEDEFS_H_INCLUDED
 
+#include "timeutils/zoneinfo.h"
+
+#define LTZ_LOCAL 0
+#define LTZ_SEND  1
+#define LTZ_MAX   2
+
 typedef struct _LogTemplateOptions LogTemplateOptions;
 typedef struct _LogTemplate LogTemplate;
+
+/* template expansion options that can be influenced by the user and
+ * is static throughout the runtime for a given configuration. There
+ * are call-site specific options too, those are specified as
+ * arguments to log_template_format() */
+struct _LogTemplateOptions
+{
+  gboolean initialized;
+  /* timestamp format as specified by ts_format() */
+  gint ts_format;
+  /* number of digits in the fraction of a second part, specified using frac_digits() */
+  gint frac_digits;
+  gboolean use_fqdn;
+
+  /* timezone for LTZ_LOCAL/LTZ_SEND settings */
+  gchar *time_zone[LTZ_MAX];
+  TimeZoneInfo *time_zone_info[LTZ_MAX];
+
+  /* Template error handling settings */
+  gint on_error;
+};
 
 #endif

--- a/lib/template/escaping.c
+++ b/lib/template/escaping.c
@@ -28,32 +28,24 @@
 #include <string.h>
 
 void
-result_append(GString *result, const gchar *sstr, gssize len, gboolean escape)
+log_template_default_escape_method(GString *result, const gchar *sstr, gsize len)
 {
-  gint i;
+  gsize i;
   const guchar *ustr = (const guchar *) sstr;
 
-  if (len < 0)
-    len = strlen(sstr);
-
-  if (escape)
+  for (i = 0; i < len; i++)
     {
-      for (i = 0; i < len; i++)
+      if (ustr[i] == '\'' || ustr[i] == '"' || ustr[i] == '\\')
         {
-          if (ustr[i] == '\'' || ustr[i] == '"' || ustr[i] == '\\')
-            {
-              g_string_append_c(result, '\\');
-              g_string_append_c(result, ustr[i]);
-            }
-          else if (ustr[i] < ' ')
-            {
-              g_string_append_c(result, '\\');
-              format_uint32_padded(result, 3, '0', 8, ustr[i]);
-            }
-          else
-            g_string_append_c(result, ustr[i]);
+          g_string_append_c(result, '\\');
+          g_string_append_c(result, ustr[i]);
         }
+      else if (ustr[i] < ' ')
+        {
+          g_string_append_c(result, '\\');
+          format_uint32_padded(result, 3, '0', 8, ustr[i]);
+        }
+      else
+        g_string_append_c(result, ustr[i]);
     }
-  else
-    g_string_append_len(result, sstr, len);
 }

--- a/lib/template/escaping.h
+++ b/lib/template/escaping.h
@@ -27,6 +27,8 @@
 
 #include "syslog-ng.h"
 
-void result_append(GString *result, const gchar *sstr, gssize len, gboolean escape);
+typedef void (*LogTemplateEscapeFunction)(GString *target, const gchar *value, gsize value_len);
+
+void log_template_default_escape_method(GString *result, const gchar *sstr, gsize len);
 
 #endif

--- a/lib/template/eval.c
+++ b/lib/template/eval.c
@@ -89,7 +89,7 @@ log_template_append_elem_macro(LogTemplate *self, LogTemplateElem *e, LogTemplat
 
   if (e->macro)
     {
-      log_macro_expand(e->macro, FALSE, options, msg, result, &value_type);
+      log_macro_expand(e->macro, options, msg, result, &value_type);
       if (len == result->len && e->default_value)
         g_string_append(result, e->default_value);
       *type = _propagate_type(*type, value_type);

--- a/lib/template/eval.c
+++ b/lib/template/eval.c
@@ -206,7 +206,10 @@ log_template_append_format_value_and_type_with_context(LogTemplate *self, LogMes
 
       if (escape)
         {
-          result_append(result, target_buffer->str, target_buffer->len, escape);
+          if (options->escape)
+            options->escape(result, target_buffer->str, target_buffer->len);
+          else
+            log_template_default_escape_method(result, target_buffer->str, target_buffer->len);
           t = LM_VT_STRING;
         }
     }

--- a/lib/template/eval.c
+++ b/lib/template/eval.c
@@ -99,7 +99,7 @@ log_template_append_elem_macro(LogTemplate *self, LogTemplateElem *e, LogTemplat
 static void
 log_template_append_elem_func(LogTemplate *self, LogTemplateElem *e, LogTemplateEvalOptions *options,
                               LogMessage **messages, gint num_messages, gint msg_ndx,
-                              LogMessageValueType *type, GString *result)
+                              LogMessageValueType *type, GString *result, gboolean escape)
 {
   LogTemplateInvokeArgs args =
   {
@@ -108,7 +108,10 @@ log_template_append_elem_func(LogTemplate *self, LogTemplateElem *e, LogTemplate
     options,
   };
   LogMessageValueType value_type = LM_VT_NONE;
+  GString *target_buffer = result;
 
+  if (escape)
+    target_buffer = scratch_buffers_alloc();
 
   /* if a function call is called with an msg_ref, we only
    * pass that given logmsg to argument resolution, otherwise
@@ -117,7 +120,14 @@ log_template_append_elem_func(LogTemplate *self, LogTemplateElem *e, LogTemplate
    */
   if (e->func.ops->eval)
     e->func.ops->eval(e->func.ops, e->func.state, &args);
-  e->func.ops->call(e->func.ops, e->func.state, &args, result, &value_type);
+  e->func.ops->call(e->func.ops, e->func.state, &args, target_buffer, &value_type);
+
+  if (escape)
+    {
+      result_append(result, target_buffer->str, target_buffer->len, escape);
+      value_type = LM_VT_STRING;
+    }
+
   *type = _propagate_type(*type, value_type);
 }
 
@@ -192,7 +202,7 @@ log_template_append_format_value_and_type_with_context(LogTemplate *self, LogMes
           log_template_append_elem_macro(self, e, options, messages[msg_ndx], &t, result, escape);
           break;
         case LTE_FUNC:
-          log_template_append_elem_func(self, e, options, messages, num_messages, msg_ndx, &t, result);
+          log_template_append_elem_func(self, e, options, messages, num_messages, msg_ndx, &t, result, escape);
           break;
         default:
           g_assert_not_reached();

--- a/lib/template/eval.c
+++ b/lib/template/eval.c
@@ -66,11 +66,11 @@ log_template_append_elem_value(LogTemplate *self, LogTemplateElem *e, LogTemplat
   value = log_msg_get_value_with_type(msg, e->value_handle, &value_len, &value_type);
   if (value && _should_render(value, value_type, self->type_hint))
     {
-      result_append(result, value, value_len, FALSE);
+      g_string_append_len(result, value, value_len);
     }
   else if (e->default_value)
     {
-      result_append(result, e->default_value, -1, FALSE);
+      g_string_append_len(result, e->default_value, -1);
       value_type = LM_VT_STRING;
     }
   else if (value_type == LM_VT_BYTES || value_type == LM_VT_PROTOBUF)

--- a/lib/template/eval.h
+++ b/lib/template/eval.h
@@ -27,6 +27,7 @@
 
 #include "syslog-ng.h"
 #include "common-template-typedefs.h"
+#include "escaping.h"
 #include "logmsg/logmsg.h"
 
 typedef struct _LogTemplateEvalOptions
@@ -37,6 +38,7 @@ typedef struct _LogTemplateEvalOptions
   gint seq_num;
   const gchar *context_id;
   LogMessageValueType context_id_type;
+  LogTemplateEscapeFunction escape;
 } LogTemplateEvalOptions;
 
 #define DEFAULT_TEMPLATE_EVAL_OPTIONS ((LogTemplateEvalOptions){NULL, LTZ_LOCAL, 0, NULL, LM_VT_STRING})

--- a/lib/template/eval.h
+++ b/lib/template/eval.h
@@ -27,33 +27,7 @@
 
 #include "syslog-ng.h"
 #include "common-template-typedefs.h"
-#include "timeutils/zoneinfo.h"
 #include "logmsg/logmsg.h"
-
-#define LTZ_LOCAL 0
-#define LTZ_SEND  1
-#define LTZ_MAX   2
-
-/* template expansion options that can be influenced by the user and
- * is static throughout the runtime for a given configuration. There
- * are call-site specific options too, those are specified as
- * arguments to log_template_format() */
-struct _LogTemplateOptions
-{
-  gboolean initialized;
-  /* timestamp format as specified by ts_format() */
-  gint ts_format;
-  /* number of digits in the fraction of a second part, specified using frac_digits() */
-  gint frac_digits;
-  gboolean use_fqdn;
-
-  /* timezone for LTZ_LOCAL/LTZ_SEND settings */
-  gchar *time_zone[LTZ_MAX];
-  TimeZoneInfo *time_zone_info[LTZ_MAX];
-
-  /* Template error handling settings */
-  gint on_error;
-};
 
 typedef struct _LogTemplateEvalOptions
 {

--- a/lib/template/globals.c
+++ b/lib/template/globals.c
@@ -1,0 +1,23 @@
+#include "templates.h"
+#include "macros.h"
+
+static LogTemplateOptions global_template_options;
+
+LogTemplateOptions *
+log_template_get_global_template_options(void)
+{
+  return &global_template_options;
+}
+
+void
+log_template_global_init(void)
+{
+  log_template_options_global_defaults(&global_template_options);
+  log_macros_global_init();
+}
+
+void
+log_template_global_deinit(void)
+{
+  log_macros_global_deinit();
+}

--- a/lib/template/globals.h
+++ b/lib/template/globals.h
@@ -1,0 +1,11 @@
+#ifndef TEMPLATES_GLOBALS_INCLUDED
+#define TEMPLATES_GLOBALS_INCLUDED
+
+#include "common-template-typedefs.h"
+
+LogTemplateOptions *log_template_get_global_template_options(void);
+
+void log_template_global_init(void);
+void log_template_global_deinit(void);
+
+#endif

--- a/lib/template/macros.c
+++ b/lib/template/macros.c
@@ -23,6 +23,7 @@
  */
 
 #include "template/macros.h"
+#include "template/globals.h"
 #include "template/escaping.h"
 #include "timeutils/cache.h"
 #include "timeutils/names.h"
@@ -229,7 +230,6 @@ LogMacroDef macros[] =
 
 static GTimeVal app_uptime;
 static GHashTable *macro_hash;
-static LogTemplateOptions template_options_for_macro_expand;
 
 static void
 _result_append_value(GString *result, const LogMessage *lm, NVHandle handle, gboolean escape)
@@ -724,7 +724,7 @@ log_macro_expand(gint id, gboolean escape, LogTemplateEvalOptions *options, cons
 gboolean
 log_macro_expand_simple(gint id, const LogMessage *msg, GString *result, LogMessageValueType *type)
 {
-  LogTemplateEvalOptions options = {&template_options_for_macro_expand, LTZ_LOCAL, 0, NULL, LM_VT_STRING};
+  LogTemplateEvalOptions options = {log_template_get_global_template_options(), LTZ_LOCAL, 0, NULL, LM_VT_STRING};
   return log_macro_expand(id, FALSE, &options, msg, result, type);
 }
 
@@ -749,7 +749,6 @@ log_macros_global_init(void)
 
   /* init the uptime (SYSUPTIME macro) */
   g_get_current_time(&app_uptime);
-  log_template_options_global_defaults(&template_options_for_macro_expand);
 
   macro_hash = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
   for (i = 0; macros[i].name; i++)

--- a/lib/template/macros.c
+++ b/lib/template/macros.c
@@ -232,13 +232,13 @@ static GTimeVal app_uptime;
 static GHashTable *macro_hash;
 
 static void
-_result_append_value(GString *result, const LogMessage *lm, NVHandle handle, gboolean escape)
+_result_append_value(GString *result, const LogMessage *lm, NVHandle handle)
 {
   const gchar *str;
   gssize len = 0;
 
   str = log_msg_get_value(lm, handle, &len);
-  result_append(result, str, len, escape);
+  g_string_append_len(result, str, len);
 }
 
 static gboolean
@@ -270,7 +270,7 @@ _is_message_dest_an_ip_address(const LogMessage *msg)
 }
 
 static void
-log_macro_expand_date_time(gint id, gboolean escape,
+log_macro_expand_date_time(gint id,
                            LogTemplateEvalOptions *options, const LogMessage *msg,
                            GString *result, LogMessageValueType *type)
 {
@@ -423,7 +423,7 @@ log_macro_expand_date_time(gint id, gboolean escape,
 }
 
 gboolean
-log_macro_expand(gint id, gboolean escape, LogTemplateEvalOptions *options, const LogMessage *msg,
+log_macro_expand(gint id, LogTemplateEvalOptions *options, const LogMessage *msg,
                  GString *result, LogMessageValueType *type)
 {
   LogMessageValueType t = LM_VT_STRING;
@@ -524,28 +524,17 @@ log_macro_expand(gint id, gboolean escape, LogTemplateEvalOptions *options, cons
           length = p2 ? p2 - p1
                    : host_len - (p1 - host);
 
-          result_append(result, p1, length, escape);
+          g_string_append_len(result, p1, length);
         }
       else
         {
-          _result_append_value(result, msg, LM_V_HOST, escape);
+          _result_append_value(result, msg, LM_V_HOST);
         }
       break;
     }
     case M_SDATA:
     {
-      if (escape)
-        {
-          GString *sdstr = g_string_sized_new(0);
-
-          log_msg_append_format_sdata(msg, sdstr, options->seq_num);
-          result_append(result, sdstr->str, sdstr->len, TRUE);
-          g_string_free(sdstr, TRUE);
-        }
-      else
-        {
-          log_msg_append_format_sdata(msg, result, options->seq_num);
-        }
+      log_msg_append_format_sdata(msg, result, options->seq_num);
       break;
     }
     case M_MSGHDR:
@@ -555,29 +544,29 @@ log_macro_expand(gint id, gboolean escape, LogTemplateEvalOptions *options, cons
 
       p = log_msg_get_value(msg, LM_V_LEGACY_MSGHDR, &len);
       if (len > 0)
-        result_append(result, p, len, escape);
+        g_string_append_len(result, p, len);
       else
         {
           /* message, complete with program name and pid */
           len = result->len;
-          _result_append_value(result, msg, LM_V_PROGRAM, escape);
+          _result_append_value(result, msg, LM_V_PROGRAM);
           if (len != result->len)
             {
               const gchar *pid = log_msg_get_value(msg, LM_V_PID, &len);
               if (len > 0)
                 {
-                  result_append(result, "[", 1, FALSE);
-                  result_append(result, pid, len, escape);
-                  result_append(result, "]", 1, FALSE);
+                  g_string_append_c(result, '[');
+                  g_string_append_len(result, pid, len);
+                  g_string_append_c(result, ']');
                 }
-              result_append(result, ": ", 2, FALSE);
+              g_string_append_len(result, ": ", 2);
             }
         }
       break;
     }
     case M_MESSAGE:
     {
-      _result_append_value(result, msg, LM_V_MESSAGE, escape);
+      _result_append_value(result, msg, LM_V_MESSAGE);
       break;
     }
     case M_SOURCE_IP:
@@ -594,7 +583,7 @@ log_macro_expand(gint id, gboolean escape, LogTemplateEvalOptions *options, cons
         {
           ip = "127.0.0.1";
         }
-      result_append(result, ip, strlen(ip), escape);
+      g_string_append(result, ip);
       break;
     }
     case M_DEST_IP:
@@ -611,7 +600,7 @@ log_macro_expand(gint id, gboolean escape, LogTemplateEvalOptions *options, cons
         {
           ip = "127.0.0.1";
         }
-      result_append(result, ip, strlen(ip), escape);
+      g_string_append(result, ip);
       break;
     }
     case M_DEST_PORT:
@@ -654,7 +643,7 @@ log_macro_expand(gint id, gboolean escape, LogTemplateEvalOptions *options, cons
     {
       if (options->context_id)
         {
-          result_append(result, options->context_id, strlen(options->context_id), escape);
+          g_string_append(result, options->context_id);
           t = options->context_id_type;
         }
       break;
@@ -696,7 +685,7 @@ log_macro_expand(gint id, gboolean escape, LogTemplateEvalOptions *options, cons
                            ? get_local_hostname_fqdn()
                            : get_local_hostname_short();
 
-      result_append(result, hname, -1, escape);
+      g_string_append(result, hname);
       break;
     }
     case M_SYSUPTIME:
@@ -710,13 +699,13 @@ log_macro_expand(gint id, gboolean escape, LogTemplateEvalOptions *options, cons
 
     default:
     {
-      log_macro_expand_date_time(id, escape, options, msg, result, &t);
+      log_macro_expand_date_time(id, options, msg, result, &t);
       break;
     }
 
     }
   if (type)
-    *type = escape ? LM_VT_STRING : t;
+    *type = t;
 
   return TRUE;
 }
@@ -725,7 +714,7 @@ gboolean
 log_macro_expand_simple(gint id, const LogMessage *msg, GString *result, LogMessageValueType *type)
 {
   LogTemplateEvalOptions options = {log_template_get_global_template_options(), LTZ_LOCAL, 0, NULL, LM_VT_STRING};
-  return log_macro_expand(id, FALSE, &options, msg, result, type);
+  return log_macro_expand(id, &options, msg, result, type);
 }
 
 guint

--- a/lib/template/macros.h
+++ b/lib/template/macros.h
@@ -119,7 +119,7 @@ extern LogMacroDef macros[];
 
 /* low level macro functions */
 guint log_macro_lookup(const gchar *macro, gint len);
-gboolean log_macro_expand(gint id, gboolean escape, LogTemplateEvalOptions *options,
+gboolean log_macro_expand(gint id, LogTemplateEvalOptions *options,
                           const LogMessage *msg,
                           GString *result, LogMessageValueType *type);
 gboolean log_macro_expand_simple(gint id, const LogMessage *msg,

--- a/lib/template/simple-function.c
+++ b/lib/template/simple-function.c
@@ -52,7 +52,7 @@ tf_simple_func_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *paren
    * one. */
   for (i = 0; i < argc - 1; i++)
     {
-      state->argv_templates[i] = log_template_new(parent->cfg, NULL);
+      state->argv_templates[i] = log_template_new_embedded(parent->cfg);
       log_template_set_escape(state->argv_templates[i], parent->escape);
       if (!log_template_compile(state->argv_templates[i], argv[i + 1], error))
         {

--- a/lib/template/simple-function.c
+++ b/lib/template/simple-function.c
@@ -53,7 +53,6 @@ tf_simple_func_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *paren
   for (i = 0; i < argc - 1; i++)
     {
       state->argv_templates[i] = log_template_new_embedded(parent->cfg);
-      log_template_set_escape(state->argv_templates[i], parent->escape);
       if (!log_template_compile(state->argv_templates[i], argv[i + 1], error))
         {
           state->argc = i + 1;

--- a/lib/template/templates.c
+++ b/lib/template/templates.c
@@ -367,6 +367,15 @@ log_template_new(GlobalConfig *cfg, const gchar *name)
   else
     self->type_hint = LM_VT_NONE;
   self->explicit_type_hint = LM_VT_NONE;
+  self->top_level = TRUE;
+  return self;
+}
+
+LogTemplate *
+log_template_new_embedded(GlobalConfig *cfg)
+{
+  LogTemplate *self = log_template_new(cfg, NULL);
+  self->top_level = FALSE;
   return self;
 }
 

--- a/lib/template/templates.c
+++ b/lib/template/templates.c
@@ -478,18 +478,6 @@ log_template_error_quark(void)
   return g_quark_from_static_string("log-template-error-quark");
 }
 
-void
-log_template_global_init(void)
-{
-  log_macros_global_init();
-}
-
-void
-log_template_global_deinit(void)
-{
-  log_macros_global_deinit();
-}
-
 gboolean
 log_template_on_error_parse(const gchar *strictness, gint *out)
 {

--- a/lib/template/templates.h
+++ b/lib/template/templates.h
@@ -59,8 +59,7 @@ struct _LogTemplate
   gchar *template_str;
   GList *compiled_template;
   GlobalConfig *cfg;
-  guint escape:1, def_inline:1, trivial:1, literal:1;
-
+  guint top_level:1, escape:1, def_inline:1, trivial:1, literal:1;
 
   /* This value stores the type-hint the user _explicitly_ specified.  If
    * this is an automatic cast to string (in compat mode), this would be
@@ -92,6 +91,7 @@ const gchar *log_template_get_trivial_value_and_type(LogTemplate *self, LogMessa
 void log_template_set_name(LogTemplate *self, const gchar *name);
 
 LogTemplate *log_template_new(GlobalConfig *cfg, const gchar *name);
+LogTemplate *log_template_new_embedded(GlobalConfig *cfg);
 LogTemplate *log_template_ref(LogTemplate *s);
 void log_template_unref(LogTemplate *s);
 

--- a/lib/template/templates.h
+++ b/lib/template/templates.h
@@ -101,9 +101,6 @@ void log_template_options_destroy(LogTemplateOptions *options);
 void log_template_options_defaults(LogTemplateOptions *options);
 void log_template_options_global_defaults(LogTemplateOptions *options);
 
-void log_template_global_init(void);
-void log_template_global_deinit(void);
-
 gboolean log_template_on_error_parse(const gchar *on_error, gint *out);
 void log_template_options_set_on_error(LogTemplateOptions *options, gint on_error);
 

--- a/lib/template/tests/test_macro.c
+++ b/lib/template/tests/test_macro.c
@@ -110,7 +110,7 @@ Test(macro, test_context_id_type_is_returned)
 
   LogTemplateEvalOptions options = {NULL, LTZ_SEND, 5555, "5678", LM_VT_INTEGER};
 
-  gboolean result = log_macro_expand(M_CONTEXT_ID, FALSE, &options, msg, resolved, &type);
+  gboolean result = log_macro_expand(M_CONTEXT_ID, &options, msg, resolved, &type);
   cr_assert(result);
   cr_assert_str_eq(resolved->str, "5678");
   cr_assert_eq(type, LM_VT_INTEGER);

--- a/lib/template/tests/test_template.c
+++ b/lib/template/tests/test_template.c
@@ -414,6 +414,11 @@ Test(template, test_multi_thread)
 
 Test(template, test_escaping)
 {
+  assert_template_format_with_escaping("$(echo ${APP.QVALUE})", TRUE, "\\\"value\\\"");
+  assert_template_format_with_escaping("$(echo ${APP.QVALUE}) ${APP.QVALUE}", TRUE, "\\\"value\\\" \\\"value\\\"");
+  assert_template_format_with_escaping("$(echo $(echo $(echo ${APP.QVALUE})))", TRUE, "\\\"value\\\"");
+  assert_template_format_with_escaping("$(echo $(echo $(length ${APP.QVALUE})))", TRUE, "7");
+
   assert_template_format_with_escaping("${APP.QVALUE}", FALSE, "\"value\"");
   assert_template_format_with_escaping("${APP.QVALUE}", TRUE, "\\\"value\\\"");
   assert_template_format_with_escaping("$(if (\"${APP.VALUE}\" eq \"value\") \"${APP.QVALUE}\" \"${APP.QVALUE}\")",

--- a/lib/template/tests/test_template_compile.c
+++ b/lib/template/tests/test_template_compile.c
@@ -28,6 +28,7 @@
 
 #include "template/templates.c"
 #include "template/simple-function.h"
+#include "template/globals.h"
 #include "logmsg/logmsg.h"
 #include "apphook.h"
 #include "cfg.h"

--- a/lib/value-pairs/value-pairs.c
+++ b/lib/value-pairs/value-pairs.c
@@ -387,7 +387,7 @@ vp_merge_builtins(ValuePairs *vp, VPResults *results, LogMessage *msg, LogTempla
       switch (spec->type)
         {
         case VPT_MACRO:
-          log_macro_expand(spec->id, FALSE, options, msg, sb, &type);
+          log_macro_expand(spec->id, options, msg, sb, &type);
           break;
         case VPT_NVPAIR:
         {

--- a/modules/diskq/dqtool.c
+++ b/modules/diskq/dqtool.c
@@ -23,7 +23,7 @@
 
 #include "syslog-ng.h"
 #include "logqueue.h"
-#include "template/templates.h"
+#include "template/globals.h"
 #include "logmsg/logmsg.h"
 #include "messages.h"
 #include "logpipe.h"

--- a/modules/http/http-grammar.ym
+++ b/modules/http/http-grammar.ym
@@ -144,7 +144,12 @@ response_action_item
     ;
 
 http_option
-    : KW_URL        '(' string_list ')'        { http_dd_set_urls(last_driver, $3); g_list_free_full($3, free); }
+    : KW_URL '(' string_list ')'
+      {
+        GError *error = NULL;
+        CHECK_ERROR_GERROR(http_dd_set_urls(last_driver, $3, &error), @3, error, "Error setting url");
+        g_list_free_full($3, free);
+      }
     | KW_USER       '(' string ')'            { http_dd_set_user(last_driver, $3); free($3); }
     | KW_PASSWORD   '(' string ')'            { http_dd_set_password(last_driver, $3); free($3); }
     | KW_USER_AGENT '(' string ')'            { http_dd_set_user_agent(last_driver, $3); free($3); }

--- a/modules/http/http-loadbalancer.c
+++ b/modules/http/http-loadbalancer.c
@@ -23,6 +23,7 @@
 
 #include "http-loadbalancer.h"
 #include "messages.h"
+#include "str-utils.h"
 #include <string.h>
 
 /* HTTPLoadBalancerTarget */
@@ -33,6 +34,7 @@ http_lb_target_init(HTTPLoadBalancerTarget *self, const gchar *url, gint index_,
   memset(self, 0, sizeof(*self));
 
   LogTemplate *url_template = log_template_new(configuration, NULL);
+  log_template_set_escape(url_template, TRUE);
   if (!log_template_compile(url_template, url, error))
     {
       log_template_unref(url_template);
@@ -65,11 +67,23 @@ http_lb_target_get_literal_url(HTTPLoadBalancerTarget *self)
   return log_template_get_literal_value(self->url_template, NULL);
 }
 
+static void
+_escape_urlencoded(GString *result, const gchar *value, gsize value_len)
+{
+  APPEND_ZERO(value, value, value_len);
+  g_string_append_uri_escaped(result, value, NULL, FALSE);
+}
+
 void
 http_lb_target_format_templated_url(HTTPLoadBalancerTarget *self, LogMessage *msg,
                                     const LogTemplateOptions *template_options, GString *result)
 {
-  LogTemplateEvalOptions template_eval_options = { template_options, LTZ_SEND, -1, NULL, LM_VT_STRING };
+  LogTemplateEvalOptions template_eval_options = {
+    .opts = template_options,
+    .tz = LTZ_LOCAL,
+    .seq_num = -1,
+    .escape = _escape_urlencoded,
+  };
   log_template_format(self->url_template, msg, &template_eval_options, result);
 }
 

--- a/modules/http/http-loadbalancer.c
+++ b/modules/http/http-loadbalancer.c
@@ -45,6 +45,7 @@ http_lb_target_init(HTTPLoadBalancerTarget *self, const gchar *url, gint index_,
   self->url_template = url_template;
   self->state = HTTP_TARGET_OPERATIONAL;
   self->index = index_;
+  g_snprintf(self->formatted_index, sizeof(self->formatted_index), "%d", index_);
 
   return TRUE;
 }
@@ -82,6 +83,8 @@ http_lb_target_format_templated_url(HTTPLoadBalancerTarget *self, LogMessage *ms
     .opts = template_options,
     .tz = LTZ_LOCAL,
     .seq_num = -1,
+    .context_id = self->formatted_index,
+    .context_id_type = LM_VT_INTEGER,
     .escape = _escape_urlencoded,
   };
   log_template_format(self->url_template, msg, &template_eval_options, result);

--- a/modules/http/http-loadbalancer.h
+++ b/modules/http/http-loadbalancer.h
@@ -24,7 +24,6 @@
 #ifndef HTTP_LOADBALANCER_H_INCLUDED
 #define HTTP_LOADBALANCER_H_INCLUDED 1
 
-#include "syslog-ng.h"
 #include "template/templates.h"
 
 typedef enum
@@ -54,6 +53,7 @@ struct _HTTPLoadBalancerTarget
   gint number_of_clients;
   gint max_clients;
   time_t last_failure_time;
+  gchar formatted_index[16];
 };
 
 gboolean http_lb_target_is_url_templated(HTTPLoadBalancerTarget *self);

--- a/modules/http/http-loadbalancer.h
+++ b/modules/http/http-loadbalancer.h
@@ -56,6 +56,11 @@ struct _HTTPLoadBalancerTarget
   time_t last_failure_time;
 };
 
+gboolean http_lb_target_is_url_templated(HTTPLoadBalancerTarget *self);
+const gchar *http_lb_target_get_literal_url(HTTPLoadBalancerTarget *self);
+void http_lb_target_format_templated_url(HTTPLoadBalancerTarget *self, LogMessage *msg,
+                                         const LogTemplateOptions *template_options, GString *result);
+
 struct _HTTPLoadBalancerClient
 {
   HTTPLoadBalancerTarget *target;
@@ -81,6 +86,7 @@ void http_load_balancer_drop_all_targets(HTTPLoadBalancer *self);
 void http_load_balancer_track_client(HTTPLoadBalancer *self, HTTPLoadBalancerClient *lbc);
 void http_load_balancer_set_target_failed(HTTPLoadBalancer *self, HTTPLoadBalancerTarget *target);
 void http_load_balancer_set_target_successful(HTTPLoadBalancer *self, HTTPLoadBalancerTarget *target);
+gboolean http_load_balancer_is_url_templated(HTTPLoadBalancer *self);
 
 void http_load_balancer_set_recovery_timeout(HTTPLoadBalancer *self, gint recovery_timeout);
 HTTPLoadBalancer *http_load_balancer_new(void);

--- a/modules/http/http-loadbalancer.h
+++ b/modules/http/http-loadbalancer.h
@@ -25,6 +25,7 @@
 #define HTTP_LOADBALANCER_H_INCLUDED 1
 
 #include "syslog-ng.h"
+#include "template/templates.h"
 
 typedef enum
 {
@@ -46,7 +47,7 @@ typedef struct _HTTPLoadBalancer HTTPLoadBalancer;
 struct _HTTPLoadBalancerTarget
 {
   /* read-only data, no need to lock */
-  gchar *url;
+  LogTemplate *url_template;
   gint index;
   /* read-write data, locking must be in effect */
   HTTPLoadBalancerTargetState state;
@@ -75,7 +76,7 @@ struct _HTTPLoadBalancer
 };
 
 HTTPLoadBalancerTarget *http_load_balancer_choose_target(HTTPLoadBalancer *self, HTTPLoadBalancerClient *lbc);
-void http_load_balancer_add_target(HTTPLoadBalancer *self, const gchar *url);
+gboolean http_load_balancer_add_target(HTTPLoadBalancer *self, const gchar *url, GError **error);
 void http_load_balancer_drop_all_targets(HTTPLoadBalancer *self);
 void http_load_balancer_track_client(HTTPLoadBalancer *self, HTTPLoadBalancerClient *lbc);
 void http_load_balancer_set_target_failed(HTTPLoadBalancer *self, HTTPLoadBalancerTarget *target);

--- a/modules/http/http-worker.c
+++ b/modules/http/http-worker.c
@@ -671,6 +671,12 @@ _format_request_headers_catch_error(GError **error)
   return !unhandled;
 }
 
+static const gchar *
+_get_url(HTTPDestinationWorker *self, HTTPLoadBalancerTarget *target)
+{
+  return log_template_get_literal_value(target->url_template, NULL);
+}
+
 /* we flush the accumulated data if
  *   1) we reach batch_size,
  *   2) the message queue becomes empty
@@ -700,7 +706,7 @@ _flush(LogThreadedDestWorker *s, LogThreadedFlushMode mode)
     }
 
   target = http_load_balancer_choose_target(owner->load_balancer, &self->lbc);
-  const gchar *url = target->url;
+  const gchar *url = _get_url(self, target);
 
   while (--retry_attempts >= 0)
     {
@@ -727,7 +733,7 @@ _flush(LogThreadedDestWorker *s, LogThreadedFlushMode mode)
           break;
         }
 
-      const gchar *alt_url = alt_target->url;
+      const gchar *alt_url = _get_url(self, alt_target);
       msg_debug("Target server down, trying an alternative server",
                 evt_tag_str("url", url),
                 evt_tag_str("alternative_url", alt_url),

--- a/modules/http/http-worker.h
+++ b/modules/http/http-worker.h
@@ -39,6 +39,8 @@ typedef struct _HTTPDestinationWorker
   GString *request_body_compressed;
   Compressor *compressor;
   List *request_headers;
+  GString *url_buffer;
+  LogMessage *msg_for_templated_url;
 } HTTPDestinationWorker;
 
 LogThreadedResult default_map_http_status_to_worker_status(HTTPDestinationWorker *self, const gchar *url,

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -503,6 +503,8 @@ http_dd_new(GlobalConfig *cfg)
   self->super.stats_source = stats_register_type("http");
   self->super.worker.construct = http_dw_new;
 
+  log_threaded_dest_driver_set_flush_on_worker_key_change(&self->super.super.super, TRUE);
+
   curl_global_init(CURL_GLOBAL_ALL);
 
   self->ssl_version = CURL_SSLVERSION_DEFAULT;

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -435,6 +435,17 @@ http_dd_init(LogPipe *s)
   if (!log_threaded_dest_driver_init_method(s))
     return FALSE;
 
+  if ((self->super.batch_lines || self->batch_bytes) && http_load_balancer_is_url_templated(self->load_balancer) &&
+      self->super.num_workers > 1 && !self->super.worker_partition_key)
+    {
+      msg_error("worker-partition-key() must be set if using templates in the url() option "
+                "while batching is enabled and multiple workers are configured. "
+                "Make sure to set worker-partition-key() with a template that contains all the templates "
+                "used in the url() option",
+                log_pipe_location_tag(&self->super.super.super.super));
+      return FALSE;
+    }
+
   log_template_options_init(&self->template_options, cfg);
 
   http_load_balancer_set_recovery_timeout(self->load_balancer, self->super.time_reopen);

--- a/modules/http/http.h
+++ b/modules/http/http.h
@@ -39,8 +39,8 @@ typedef struct
   HTTPLoadBalancer *load_balancer;
 
   /* this is the first URL in load-balanced configurations and serves as the
-   * identifier in persist/stats */
-  gchar *url;
+   * identifier in persist/stats. TODO: Templated URLs should have dynamic counters. */
+  const gchar *url;
   gchar *user;
   gchar *password;
   GList *headers;
@@ -73,7 +73,7 @@ gboolean http_dd_init(LogPipe *s);
 gboolean http_dd_deinit(LogPipe *s);
 LogDriver *http_dd_new(GlobalConfig *cfg);
 
-void http_dd_set_urls(LogDriver *d, GList *urls);
+gboolean http_dd_set_urls(LogDriver *d, GList *urls, GError **error);
 void http_dd_set_user(LogDriver *d, const gchar *user);
 void http_dd_set_password(LogDriver *d, const gchar *password);
 void http_dd_set_method(LogDriver *d, const gchar *method);

--- a/modules/http/tests/test_http-loadbalancer.c
+++ b/modules/http/tests/test_http-loadbalancer.c
@@ -41,7 +41,8 @@ _construct_load_balancer(void)
     {
       gchar url[256];
       g_snprintf(url, sizeof(url), "http://localhost:%d", 8000 + i);
-      http_load_balancer_add_target(lb, url);
+      GError *error = NULL;
+      cr_assert(http_load_balancer_add_target(lb, url, &error));
     }
   return lb;
 }
@@ -96,7 +97,7 @@ Test(http_loadbalancer, choose_target_selects_the_first_operational_target)
   http_lb_client_init(&lbc, lb);
 
   HTTPLoadBalancerTarget *target = http_load_balancer_choose_target(lb, &lbc);
-  cr_assert(target->url, "http://localhost:8000");
+  cr_assert(log_template_get_literal_value(target->url_template, NULL), "http://localhost:8000");
   cr_assert(target->state == HTTP_TARGET_OPERATIONAL);
 
   http_lb_client_deinit(&lbc);

--- a/news/feature-4663.md
+++ b/news/feature-4663.md
@@ -1,0 +1,11 @@
+`http()`: Added support for using templates in the `url()` option.
+
+In syslog-ng a template can only be resolved on a single message, as the same
+template might have different resolutions on different messages. A http batch
+consists of multiple messages, so it is not trivial to decide which message should
+be used for the resolution.
+
+When batching is enabled and multiple workers are configured it is important to
+only batch messages which generate identical URLs. In this scenario one must set
+the `worker-partition-key()` option with a template that contains all the templates
+used in the `url()` option, otherwise messages will be mixed.

--- a/tests/light/functional_tests/templates/test_template_stmt.py
+++ b/tests/light/functional_tests/templates/test_template_stmt.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2019 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+
+def test_template_stmt_with_identifier_reference(config, syslog_ng):
+    template = config.create_template("template with $(format-welf test.*)\n")
+    config.add_template(template)
+
+    generator_source = config.create_example_msg_generator_source(num=1, values="test.key1 => value1 test.key2 => value2")
+    file_destination = config.create_file_destination(file_name="output.log", template=template.name)
+
+    config.create_logpath(statements=[generator_source, file_destination])
+    syslog_ng.start(config)
+    log = file_destination.read_logs(1)
+    assert log == ["template with test.key1=value1 test.key2=value2\n"]
+
+
+def test_template_with_non_string_values(config, syslog_ng):
+
+    generator_source = config.create_example_msg_generator_source(num=1, values="test.key1 => value1 test.key2 => value2")
+    rewrites = [
+        config.create_rewrite_set("int(10)", value="values_int_hint"),
+        config.create_rewrite_set("float(4.5)", value="values_float_hint"),
+        config.create_rewrite_set("10", value="values_int_literal"),
+        config.create_rewrite_set("4.5", value="values_float_literal")
+    ]
+    file_destination = config.create_file_destination(file_name="output.log", template=config.stringify("$(format-json values_*)\n"))
+
+    config.create_logpath(statements=[generator_source, *rewrites, file_destination])
+    syslog_ng.start(config)
+    log = file_destination.read_logs(1)
+    assert log == ["""{"values_int_literal":10,"values_int_hint":10,"values_float_literal":4.5,"values_float_hint":4.5}\n"""]
+
+
+def test_template_stmt_with_indirect_invocation(config, syslog_ng):
+    template = config.create_template("template with $(format-welf test.*)\n")
+    config.add_template(template)
+
+    generator_source = config.create_example_msg_generator_source(num=1, values="test.key1 => value1 test.key2 => value2 template_fn => {}".format(template.name))
+    file_destination = config.create_file_destination(file_name="output.log", template=config.stringify("$(template {} error resolving template)\n".format(template.name)))
+
+    config.create_logpath(statements=[generator_source, file_destination])
+    syslog_ng.start(config)
+    log = file_destination.read_logs(1)
+    assert log == ["template with test.key1=value1 test.key2=value2\n"]
+
+
+def test_simple_template_stmt_with_identifier_reference(config, syslog_ng):
+    template = config.create_template("template with $(format-welf test.*)\n", use_simple_statement=True)
+    config.add_template(template)
+
+    generator_source = config.create_example_msg_generator_source(num=1, values="test.key1 => value1 test.key2 => value2")
+    file_destination = config.create_file_destination(file_name="output.log", template=template.name)
+
+    config.create_logpath(statements=[generator_source, file_destination])
+    syslog_ng.start(config)
+    log = file_destination.read_logs(1)
+    assert log == ["template with test.key1=value1 test.key2=value2\n"]
+
+
+def test_template_stmt_with_string_reference(config, syslog_ng):
+    template = config.create_template("template with $(format-welf test.*)\n")
+    config.add_template(template)
+
+    generator_source = config.create_example_msg_generator_source(num=1, values="test.key1 => value1 test.key2 => value2")
+    file_destination = config.create_file_destination(file_name="output.log", template=config.stringify(template.name))
+
+    config.create_logpath(statements=[generator_source, file_destination])
+    syslog_ng.start(config)
+    log = file_destination.read_logs(1)
+    assert log == ["template with test.key1=value1 test.key2=value2\n"]
+
+
+def test_inline_template(config, syslog_ng):
+    generator_source = config.create_example_msg_generator_source(num=1, values="test.key1 => value1 test.key2 => value2")
+    file_destination = config.create_file_destination(file_name="output.log", template=config.stringify("template with $(format-welf test.*)\n"))
+
+    config.create_logpath(statements=[generator_source, file_destination])
+    syslog_ng.start(config)
+    log = file_destination.read_logs(1)
+    assert log == ["template with test.key1=value1 test.key2=value2\n"]
+
+
+def test_template_function(config, syslog_ng):
+    template = config.create_template_function("template with $(format-welf test.*)\n", name="test_template_fn")
+    config.add_template(template)
+
+    generator_source = config.create_example_msg_generator_source(num=1, values="test.key1 => value1 test.key2 => value2")
+    file_destination = config.create_file_destination(file_name="output.log", template=config.stringify("$(test_template_fn)\n"))
+
+    config.create_logpath(statements=[generator_source, file_destination])
+    syslog_ng.start(config)
+    log = file_destination.read_logs(1)
+    assert log == ["template with test.key1=value1 test.key2=value2\n"]

--- a/tests/light/src/syslog_ng_config/__init__.py
+++ b/tests/light/src/syslog_ng_config/__init__.py
@@ -1,0 +1,3 @@
+
+def stringify(s):
+    return '"' + s.replace('\\', "\\\\").replace('"', '\\"').replace('\n', '\\n') + '"'

--- a/tests/light/src/syslog_ng_config/statements/rewrite/rewrite.py
+++ b/tests/light/src/syslog_ng_config/statements/rewrite/rewrite.py
@@ -36,6 +36,11 @@ class SetTag(Rewrite):
         super(SetTag, self).__init__("set_tag", [tag], **options)
 
 
+class Set(Rewrite):
+    def __init__(self, template, **options):
+        super(Set, self).__init__("set", [template], **options)
+
+
 class SetPri(Rewrite):
     def __init__(self, pri, **options):
         super(SetPri, self).__init__("set_pri", [pri], **options)

--- a/tests/light/src/syslog_ng_config/statements/template/template.py
+++ b/tests/light/src/syslog_ng_config/statements/template/template.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2015-2019 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+from src.common.random_id import get_unique_id
+
+
+class Template(object):
+    def __init__(self, template, name=None, escape=None, use_simple_statement=False):
+        self.template = template
+        self.template_escape = escape
+        self.name = name or "template_{}".format(get_unique_id())
+        self.use_simple_statement = escape is not None or use_simple_statement
+
+
+class TemplateFunction(object):
+    def __init__(self, template, name):
+        self.template = template
+        self.name = name

--- a/tests/light/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/light/src/syslog_ng_config/syslog_ng_config.py
@@ -42,10 +42,12 @@ from src.syslog_ng_config.statements.rewrite.rewrite import CreditCardHash
 from src.syslog_ng_config.statements.rewrite.rewrite import CreditCardMask
 from src.syslog_ng_config.statements.rewrite.rewrite import SetPri
 from src.syslog_ng_config.statements.rewrite.rewrite import SetTag
+from src.syslog_ng_config.statements.rewrite.rewrite import Set
 from src.syslog_ng_config.statements.sources.example_msg_generator_source import ExampleMsgGeneratorSource
 from src.syslog_ng_config.statements.sources.file_source import FileSource
 from src.syslog_ng_config.statements.sources.internal_source import InternalSource
 from src.syslog_ng_config.statements.sources.network_source import NetworkSource
+from src.syslog_ng_config.statements.template.template import Template, TemplateFunction
 
 
 logger = logging.getLogger(__name__)
@@ -58,6 +60,7 @@ class SyslogNgConfig(object):
             "version": version,
             "includes": [],
             "global_options": {},
+            "templates": [],
             "statement_groups": [],
             "logpath_groups": [],
         }
@@ -90,6 +93,9 @@ class SyslogNgConfig(object):
     def update_global_options(self, **options):
         self.__syslog_ng_config["global_options"].update(options)
 
+    def add_template(self, template):
+        self.__syslog_ng_config["templates"].append(template)
+
     def create_file_source(self, **options):
         file_source = FileSource(**options)
         self.teardown.register(file_source.close_file)
@@ -112,6 +118,12 @@ class SyslogNgConfig(object):
 
     def create_rewrite_set_pri(self, pri, **options):
         return SetPri(pri, **options)
+
+    def create_template(self, template, **options):
+        return Template(template, **options)
+
+    def create_template_function(self, template, **options):
+        return TemplateFunction(template, **options)
 
     def create_filter(self, expr=None, **options):
         return Filter("", [expr] if expr else [], **options)

--- a/tests/light/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/light/src/syslog_ng_config/syslog_ng_config.py
@@ -24,6 +24,7 @@ import logging
 
 from src.common.file import File
 from src.common.operations import cast_to_list
+from src.syslog_ng_config import stringify
 from src.syslog_ng_config.renderer import ConfigRenderer
 from src.syslog_ng_config.statement_group import StatementGroup
 from src.syslog_ng_config.statements.destinations.example_destination import ExampleDestination
@@ -62,9 +63,7 @@ class SyslogNgConfig(object):
         }
         self.teardown = teardown
 
-    @staticmethod
-    def stringify(s):
-        return '"' + s.replace('\\', "\\\\").replace('"', '\\"').replace('\n', '\\n') + '"'
+    stringify = staticmethod(stringify)
 
     def set_raw_config(self, raw_config):
         self.__raw_config = raw_config

--- a/tests/light/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/light/src/syslog_ng_config/syslog_ng_config.py
@@ -104,6 +104,9 @@ class SyslogNgConfig(object):
     def create_network_source(self, **options):
         return NetworkSource(**options)
 
+    def create_rewrite_set(self, template, **options):
+        return Set(template, **options)
+
     def create_rewrite_set_tag(self, tag, **options):
         return SetTag(tag, **options)
 


### PR DESCRIPTION
This branch adds the new [#4666](https://github.com/syslog-ng/syslog-ng/pull/4666)  plus a couple of patches to your http stuff so that we properly escape the URLs as needed.

Instead of merging this, you might want to rebase against #4666 and add the last two patches only.